### PR TITLE
make it possible to edit device names in both device lists

### DIFF
--- a/resources/public/css/screen.css
+++ b/resources/public/css/screen.css
@@ -66,3 +66,6 @@ body {
     }
 }
 
+.editing .view {
+    display: none;
+}

--- a/src/cljs/homeautomation/misc.cljs
+++ b/src/cljs/homeautomation/misc.cljs
@@ -2,7 +2,7 @@
   (:require [cljs-time.core :as t]
             [cljs-time.coerce :as c]
             [cljs-time.format :as f]
-            ))
+            [reagent.core :as r]))
 
 (def my-formatter (f/formatter "yyyy-MM-dd HH:mm:ss"))
 (defn fmt-time [t]
@@ -65,4 +65,22 @@
                      [:td
                       (render-cell (get row column))]))))]]))
 
+(defn input-field [{:keys [initial on-save on-stop]}]
+  (let [val (r/atom initial)
+        stop #(do (reset! val "")
+                  (if on-stop (on-stop)))
+        save #(let [v (-> @val str clojure.string/trim)]
+               (if-not (empty? v) (on-save v))
+               (stop))]
+    (fn [props]
+      [:input (merge props
+                     {:type        "text" :value @val :on-blur save
+                      :on-change   #(reset! val (-> % .-target .-value))
+                      :on-key-down #(case (.-which %)
+                                     13 (save)
+                                     27 (stop)
+                                     nil)})])))
+
+(def edit-field (with-meta input-field
+                           {:component-did-mount #(.focus (r/dom-node %))}))
 


### PR DESCRIPTION
This change adds support for adding a new device name in the macaddrs table, and editing an existing device name in the devices table. No support yet for deleting a device name, but this does fix two issues...

Fixes #5, #16.